### PR TITLE
Add defender spawn and pre-round freeze time

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>Top‑Down Bomb (v7.5 • anti‑stuck AI)</title>
+<title>Top‑Down Bomb (v7.6 • defender spawn)</title>
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
 <style>
   html,body { height:100%; }
@@ -21,8 +21,8 @@
 <div id="hud"></div>
 <div id="status"></div>
 <div id="overlay"><div id="panel">
-  <h2>Top‑Down Bomb Defusal (v7.5)</h2>
-  <div class="small">Anti‑stuck AI • wide doorways • 10v10 • A/B sites • 90s rounds</div>
+  <h2>Top‑Down Bomb Defusal (v7.6)</h2>
+  <div class="small">Defender spawn • anti‑stuck AI • wide doorways • 10v10 • A/B sites • 90s rounds</div>
   <div class="small">Press <b>D</b> to toggle doorway highlights.</div>
   <br/><button id="startBtn">Start Simulation</button>
 </div></div>


### PR DESCRIPTION
## Summary
- Introduce a dedicated defender spawn room with connectors to A and B
- Spawn defenders in central spawn and lock attackers for a 10s prep phase
- Show pre-round countdown on HUD and update version to v7.6

## Testing
- `node --check main.js`
- `npx -y htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_689e961539708327806777670f9d0a74