### PR TITLE
Expand mid with new doors and spawn barrier

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>Top‑Down Bomb (v7.6 • defender spawn)</title>
+<title>Top‑Down Bomb (v7.7 • mid expansion)</title>
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
 <style>
   html,body { height:100%; }
@@ -21,7 +21,7 @@
 <div id="hud"></div>
 <div id="status"></div>
 <div id="overlay"><div id="panel">
-  <h2>Top‑Down Bomb Defusal (v7.6)</h2>
+  <h2>Top‑Down Bomb Defusal (v7.7)</h2>
   <div class="small">Defender spawn • anti‑stuck AI • wide doorways • 10v10 • A/B sites • 90s rounds</div>
   <div class="small">Press <b>D</b> to toggle doorway highlights.</div>
   <br/><button id="startBtn">Start Simulation</button>

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-// v7.6 — Defender spawn & 10s freeze time
+// v7.7 — Spawn barrier & mid expansion
 (function(){
   const canvas = document.getElementById('game');
   const ctx = canvas.getContext('2d');
@@ -68,7 +68,6 @@
 
     // Mid hub
     carveRect(W*0.36, H*0.55, W*0.64, H*0.70);
-    carveDoor(W*0.47, H*0.70, W*0.53, H*0.70+2);
 
     // Left/right junctions
     carveRect(W*0.22, H*0.55, W*0.36, H*0.62);
@@ -99,6 +98,14 @@
     carveRect(W*0.58, H*0.18, W*0.70, H*0.24);
     carveDoor(W*0.40, H*0.24, W*0.42, H*0.27);
     carveDoor(W*0.58, H*0.24, W*0.60, H*0.27);
+
+    // Defender spawn connectors to sites (wider exits)
+    carveDoor(W*0.36, H*0.18, W*0.42, H*0.18+2);
+    carveDoor(W*0.58, H*0.18, W*0.64, H*0.18+2);
+
+    // Mid expansion
+    carveDoor(W*0.12, H*0.52, W*0.88, H*0.52+2); // A ↔ B across mid
+    carveDoor(W*0.47, H*0.55, W*0.53, H-18);      // Attacker spawn ↔ mid
 
     // Defender spawn room (north) and connectors
     carveRect(W*0.42, H*0.04, W*0.58, H*0.18);
@@ -491,6 +498,11 @@
     ctx.fillStyle='#101218'; ctx.fillRect(0,0,WORLD_W,WORLD_H);
     ctx.fillStyle='#d8d9df';
     for(let y=0;y<GRID_H;y++){ for(let x=0;x<GRID_W;x++){ if(walkable[y][x]) ctx.fillRect(x*TILE, y*TILE, TILE, TILE); } }
+    if(!attackerDoorOpen){
+      const d = attackerDoor;
+      ctx.fillStyle='rgba(64,128,255,0.4)';
+      ctx.fillRect(d.x0*TILE, d.y0*TILE, (d.x1-d.x0)*TILE, (d.y1-d.y0)*TILE);
+    }
     if(showDoors){
       ctx.strokeStyle='#ff66aa'; ctx.lineWidth=3;
       for(const d of doors){ ctx.strokeRect(d.x0*TILE, d.y0*TILE, (d.x1-d.x0)*TILE, (d.y1-d.y0)*TILE); }


### PR DESCRIPTION
## Summary
- Remove stray mid door that let attackers exit spawn early
- Add blue semi-transparent barrier for attackers during freeze time
- Add wide doors at defender spawn connectors and long mid doors linking A↔B and spawn↔mid

## Testing
- `node --version`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_689eb51f5ce883279f4b0556a738cf62