### PR TITLE
Raise door heights and change door toggle key

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 <div id="overlay"><div id="panel">
   <h2>Top‑Down Bomb Defusal (v7.7)</h2>
   <div class="small">Defender spawn • anti‑stuck AI • wide doorways • 10v10 • A/B sites • 90s rounds</div>
-  <div class="small">Press <b>D</b> to toggle doorway highlights.</div>
+  <div class="small">Press <b>E</b> to toggle doorway highlights.</div>
   <br/><button id="startBtn">Start Simulation</button>
 </div></div>
 <script src="main.js"></script>

--- a/main.js
+++ b/main.js
@@ -104,8 +104,8 @@
     carveDoor(W*0.58, H*0.18, W*0.64, H*0.18+2);
 
     // Mid expansion
-    carveDoor(W*0.12, H*0.52, W*0.88, H*0.52+2); // A ↔ B across mid
-    carveDoor(W*0.47, H*0.55, W*0.53, H-18);      // Attacker spawn ↔ mid
+    carveDoor(W*0.12, H*0.42, W*0.88, H*0.42+2); // A ↔ B across mid
+    carveDoor(W*0.47, H*0.45, W*0.53, H-48);      // Attacker spawn ↔ mid
 
     // Defender spawn room (north) and connectors
     carveRect(W*0.42, H*0.04, W*0.58, H*0.18);
@@ -654,7 +654,7 @@
   }
 
   // Doorway overlay toggle
-  addEventListener('keydown', (e)=>{ if(e.key==='d'||e.key==='D'){ showDoors=!showDoors; }});
+  addEventListener('keydown', (e)=>{ if(e.key==='e'||e.key==='E'){ showDoors=!showDoors; }});
 
   startBtn.addEventListener('click', ()=>{ overlay.style.display='none'; startGame(); });
 


### PR DESCRIPTION
## Summary
- Raise A↔B mid door higher and reposition attacker spawn to mid door farther north
- Switch doorway highlight toggle key from `d` to `e`

## Testing
- `node --check main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689eb69407cc8327a7bec19fdd67cc60