### PR TITLE
feat: anchor device slows attackers and rotates anchor

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>Top‑Down Bomb (v8.0 • gun visuals)</title>
+<title>Top‑Down Bomb (v8.1 • anchor slowdown)</title>
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
 <style>
   html,body { height:100%; }
@@ -28,7 +28,7 @@
  </div>
  <div id="status"></div>
 <div id="overlay"><div id="panel">
-    <h2>Top‑Down Bomb Defusal (v8.0)</h2>
+    <h2>Top‑Down Bomb Defusal (v8.1)</h2>
   <div class="small">Defender spawn • anti‑stuck AI • wide doorways • 5v5 • A/B sites • 90s rounds</div>
   <div class="small">Press <b>E</b> to toggle doorway highlights.</div>
   <br/><button id="startBtn">Start Simulation</button>

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-// v8.0 — Gun barrel visuals & fight strafing
+// v8.1 — Gun barrel visuals, fight strafing, and anchor slowdown
 (function(){
   const canvas = document.getElementById('game');
   const ctx = canvas.getContext('2d');
@@ -31,6 +31,7 @@
   const MINI_DEVICE_RADIUS = 48;
   const MINI_DEVICE_DPS = 16;
   const MINI_DEVICE_LIFETIME = 3;
+  const MINI_DEVICE_SLOW = 0.8; // 20% speed reduction
 
   // Vision cone rendering
   const VISION_FOV = Math.PI/4;
@@ -404,6 +405,7 @@
       this.facing = 0;
       this.special = false;
       this.waiting = false;
+      this.speedMult = 1;
     }
     get alive(){ return !this.dead; }
     shoot(){
@@ -474,9 +476,7 @@
           }
         }
       } else {
-        if(this.special && this.chokePoint && bomb.state!=='planted'){
-          target={x:this.chokePoint.x, y:this.chokePoint.y};
-        } else if(this.pushTarget && !this.pushDone && bomb.state!=='planted'){
+        if(this.pushTarget && !this.pushDone && bomb.state!=='planted'){
           if(preRoundTime>0){
             const idx = (this.siteIndex!=null)?this.siteIndex:nearestSite(this);
             const s=sites[idx];
@@ -564,7 +564,7 @@
       // Normalize & step with predictive sliding
       const ml=Math.hypot(mvx,mvy); if(ml>0){
         mvx/=ml; mvy/=ml;
-        const step = AI_SPEED*dt;
+        const step = AI_SPEED*dt*this.speedMult;
         this.tryStep(mvx*step, mvy*step);
         // Keep inside world
         this.x=Math.max(AGENT_RADIUS, Math.min(WORLD_W-AGENT_RADIUS, this.x));
@@ -665,6 +665,7 @@
   }
 
   function updateDevices(dt){
+    for(const a of attackers){ a.speedMult = 1; }
     for(let i=devices.length-1;i>=0;i--){
       const dev=devices[i];
       dev.life-=dt;
@@ -674,6 +675,7 @@
         const d2=(a.x-dev.x)**2+(a.y-dev.y)**2;
         if(d2 < dev.r*dev.r){
           a.hp -= dev.dps*dt;
+          a.speedMult = Math.min(a.speedMult, MINI_DEVICE_SLOW);
           if(a.hp<=0){
             a.dead=true;
             if(a.hasBomb){
@@ -853,10 +855,10 @@
       }
     }
 
+    updateDevices(dt);
     for(const a of agents) a.update(dt);
     separation();
     updateBullets(dt);
-    updateDevices(dt);
 
     // Plant/defuse edge checks
     if(bomb.state==='planting'){


### PR DESCRIPTION
## Summary
- Slow attackers caught in anchor devices by 20%
- Let the special defender rotate with the team instead of holding a choke point
- Bump simulation version to v8.1

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f13b4d438832781854ee0076c8d1a